### PR TITLE
Fix auto compression detection for stage files without extension

### DIFF
--- a/src/common/compress/src/compress_algorithms.rs
+++ b/src/common/compress/src/compress_algorithms.rs
@@ -91,4 +91,80 @@ impl CompressAlgorithm {
 
         CompressAlgorithm::from_extension(&ext)
     }
+
+    /// Try to infer compression algorithm from the binary signature.
+    ///
+    /// This is best-effort detection so we only check the magic bytes for
+    /// formats that have a well defined header. For the rest we return
+    /// `None` so the caller can decide how to handle them.
+    pub fn from_bytes(data: &[u8]) -> Option<CompressAlgorithm> {
+        if data.len() >= 2 && data[0] == 0x1F && data[1] == 0x8B {
+            return Some(CompressAlgorithm::Gzip);
+        }
+
+        if data.len() >= 4 && data[0..4] == [0x50, 0x4B, 0x03, 0x04] {
+            return Some(CompressAlgorithm::Zip);
+        }
+
+        if data.len() >= 3 && &data[..3] == b"BZh" {
+            return Some(CompressAlgorithm::Bz2);
+        }
+
+        if data.len() >= 6 && data[0..6] == [0xFD, b'7', b'z', b'X', b'Z', 0x00] {
+            return Some(CompressAlgorithm::Xz);
+        }
+
+        if data.len() >= 4 && data[0..4] == [0x28, 0xB5, 0x2F, 0xFD] {
+            return Some(CompressAlgorithm::Zstd);
+        }
+
+        if data.len() >= 2 {
+            let cmf = data[0];
+            let flg = data[1];
+            if cmf == 0x78 && ((u16::from(cmf) << 8) + u16::from(flg)) % 31 == 0 {
+                return Some(CompressAlgorithm::Zlib);
+            }
+        }
+
+        None
+    }
+
+    /// Try to infer compression algorithm from either file path or binary signature.
+    pub fn from_path_or_bytes(path: &str, data: &[u8]) -> Option<CompressAlgorithm> {
+        CompressAlgorithm::from_path(path).or_else(|| CompressAlgorithm::from_bytes(data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CompressAlgorithm;
+
+    #[test]
+    fn test_from_bytes_gzip() {
+        assert_eq!(
+            CompressAlgorithm::from_bytes(&[0x1F, 0x8B, 0x08]),
+            Some(CompressAlgorithm::Gzip)
+        );
+    }
+
+    #[test]
+    fn test_from_bytes_zip() {
+        assert_eq!(
+            CompressAlgorithm::from_bytes(&[0x50, 0x4B, 0x03, 0x04, 0x14]),
+            Some(CompressAlgorithm::Zip)
+        );
+    }
+
+    #[test]
+    fn test_from_bytes_zstd() {
+        assert_eq!(
+            CompressAlgorithm::from_bytes(&[0x28, 0xB5, 0x2F, 0xFD, 0x00]),
+            Some(CompressAlgorithm::Zstd)
+        );
+    }
+
+    #[test]
+    fn test_from_bytes_unknown() {
+        assert_eq!(CompressAlgorithm::from_bytes(&[0u8; 10]), None);
+    }
 }

--- a/src/query/storages/stage/src/read/row_based/processors/decompressor.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/decompressor.rs
@@ -44,12 +44,12 @@ impl Decompressor {
         })
     }
 
-    fn new_file(&mut self, path: String) {
+    fn new_file(&mut self, path: String, sample: &[u8]) {
         assert!(self.decompressor.is_none());
         let algo = if let Some(algo) = &self.algo {
             Some(algo.to_owned())
         } else {
-            CompressAlgorithm::from_path(&path)
+            CompressAlgorithm::from_path_or_bytes(&path, sample)
         };
         self.path = Some(path);
 
@@ -73,13 +73,12 @@ impl AccumulatingTransform for Decompressor {
             .get_owned_meta()
             .and_then(BytesBatch::downcast_from)
             .unwrap();
-        match &self.path {
-            None => self.new_file(batch.path.clone()),
-            Some(path) => {
-                if path != &batch.path {
-                    self.new_file(batch.path.clone())
-                }
-            }
+        let needs_new_file = match &self.path {
+            Some(path) if path == &batch.path => false,
+            _ => true,
+        };
+        if needs_new_file {
+            self.new_file(batch.path.clone(), &batch.data);
         }
         if matches!(self.algo, Some(CompressAlgorithm::Zip)) {
             let bytes = DecompressDecoder::decompress_all_zip(&batch.data)?;


### PR DESCRIPTION
## Summary
- add magic byte detection so COMPRESSION=AUTO works without relying on file extensions
- update the stage decompressor to reuse the new detection when a file switches

## Testing
- cargo test -p databend-common-compress

------
https://chatgpt.com/codex/tasks/task_e_68d8c9e20e1483339b136fddfd0a1ff5